### PR TITLE
feat: dashboard api implementation

### DIFF
--- a/app/api/dashboard/route.ts
+++ b/app/api/dashboard/route.ts
@@ -1,0 +1,10 @@
+import { withErrorHandler } from "@/lib/api-handler";
+import { successResponse } from "@/lib/api-helpers";
+import { requireAuth } from "@/lib/auth-helpers";
+import { getCachedDashboardData } from "@/lib/dashboard-data";
+
+export const GET = withErrorHandler(async (_req: Request) => {
+  const session = await requireAuth();
+  const data = await getCachedDashboardData(session.user.id);
+  return successResponse(data);
+});

--- a/lib/dashboard-data.ts
+++ b/lib/dashboard-data.ts
@@ -1,0 +1,259 @@
+import { unstable_cache } from "next/cache";
+import type { ItemStatus } from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+import type {
+  DashboardActivityItem,
+  DashboardApiData,
+  DashboardAssessmentSummary,
+  DashboardFrameworkScore,
+} from "@/types/dashboard";
+
+/** Same window as assessment-score SQL: exclude N/A and gateway rows from denominator; partial = 0.5 weight. */
+function weightedScorePercent(
+  items: Array<{
+    status: ItemStatus;
+    control: { weight: number; isGateway: boolean };
+  }>,
+): number {
+  let numerator = 0;
+  let denominator = 0;
+  for (const item of items) {
+    const { weight, isGateway } = item.control;
+    if (isGateway) {
+      continue;
+    }
+    if (item.status === "NOT_APPLICABLE") {
+      continue;
+    }
+    denominator += weight;
+    if (item.status === "COMPLIANT") {
+      numerator += weight;
+    } else if (item.status === "PARTIALLY_COMPLIANT") {
+      numerator += weight * 0.5;
+    }
+  }
+  if (denominator <= 0) {
+    return 0;
+  }
+  return (numerator / denominator) * 100;
+}
+
+function roundScore(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+interface ItemWithControlFramework {
+  status: ItemStatus;
+  control: {
+    weight: number;
+    isGateway: boolean;
+    frameworkId: string;
+    framework: { code: string; name: string };
+  };
+}
+
+function frameworkScoresFromItems(items: ItemWithControlFramework[]): DashboardFrameworkScore[] {
+  const byFw = new Map<string, ItemWithControlFramework[]>();
+  for (const item of items) {
+    const fid = item.control.frameworkId;
+    const list = byFw.get(fid) ?? [];
+    list.push(item);
+    byFw.set(fid, list);
+  }
+  const out: DashboardFrameworkScore[] = [];
+  for (const group of byFw.values()) {
+    const fw = group[0].control.framework;
+    out.push({
+      frameworkCode: fw.code,
+      frameworkName: fw.name,
+      score: roundScore(weightedScorePercent(group)),
+    });
+  }
+  out.sort((a, b) => a.frameworkCode.localeCompare(b.frameworkCode));
+  return out;
+}
+
+const dashboardRevalidateSec = 60;
+/** If created/updated within this window, treat as initial "created" only (one event). */
+const assessmentCreatedWindowMs = 2000;
+
+async function buildDashboardData(userId: string): Promise<DashboardApiData> {
+  const [
+    totalAssessments,
+    avgScoreAgg,
+    criticalGaps,
+    reportsGenerated,
+    reportRows,
+    assessmentActivityRows,
+    evidenceRows,
+    assessmentRows,
+  ] = await Promise.all([
+    prisma.assessment.count({ where: { userId } }),
+    prisma.assessment.aggregate({
+      where: { userId, score: { not: null } },
+      _avg: { score: true },
+    }),
+    // Critical gaps: CRITICAL controls not fully met (non-compliant or partial).
+    prisma.assessmentItem.count({
+      where: {
+        assessment: { userId },
+        control: { severity: "CRITICAL" },
+        status: { in: ["NOT_COMPLIANT", "PARTIALLY_COMPLIANT"] },
+      },
+    }),
+    prisma.report.count({
+      where: { assessment: { userId } },
+    }),
+    prisma.report.findMany({
+      where: { assessment: { userId } },
+      orderBy: { generatedAt: "desc" },
+      take: 15,
+      select: {
+        id: true,
+        generatedAt: true,
+        type: true,
+        format: true,
+      },
+    }),
+    prisma.assessment.findMany({
+      where: { userId },
+      orderBy: { updatedAt: "desc" },
+      take: 15,
+      select: {
+        id: true,
+        createdAt: true,
+        updatedAt: true,
+        status: true,
+      },
+    }),
+    prisma.evidence.findMany({
+      where: {
+        assessmentItem: {
+          assessment: { userId },
+        },
+      },
+      orderBy: { uploadedAt: "desc" },
+      take: 15,
+      select: {
+        id: true,
+        uploadedAt: true,
+        originalName: true,
+      },
+    }),
+    prisma.assessment.findMany({
+      where: { userId },
+      orderBy: { updatedAt: "desc" },
+      select: {
+        id: true,
+        status: true,
+        score: true,
+        updatedAt: true,
+        organization: {
+          select: { productName: true },
+        },
+        items: {
+          select: {
+            status: true,
+            control: {
+              select: {
+                weight: true,
+                isGateway: true,
+                frameworkId: true,
+                framework: {
+                  select: { code: true, name: true },
+                },
+              },
+            },
+          },
+        },
+      },
+    }),
+  ]);
+
+  const averageScore =
+    avgScoreAgg._avg.score !== null && avgScoreAgg._avg.score !== undefined
+      ? roundScore(Number(avgScoreAgg._avg.score))
+      : 0;
+
+  const activities: DashboardActivityItem[] = [];
+
+  for (const r of reportRows) {
+    activities.push({
+      id: `report-${r.id}`,
+      type: "report_generated",
+      title: "Report generated",
+      detail: `${r.type} (${r.format})`,
+      occurredAt: r.generatedAt.toISOString(),
+    });
+  }
+
+  for (const a of assessmentActivityRows) {
+    const delta = a.updatedAt.getTime() - a.createdAt.getTime();
+    if (delta < assessmentCreatedWindowMs) {
+      activities.push({
+        id: `assessment-created-${a.id}`,
+        type: "assessment_created",
+        title: "Assessment created",
+        detail: `Status: ${a.status}`,
+        occurredAt: a.createdAt.toISOString(),
+      });
+    } else {
+      activities.push({
+        id: `assessment-updated-${a.id}`,
+        type: "assessment_updated",
+        title: "Assessment updated",
+        detail: `Status: ${a.status}`,
+        occurredAt: a.updatedAt.toISOString(),
+      });
+    }
+  }
+
+  for (const e of evidenceRows) {
+    activities.push({
+      id: `evidence-${e.id}`,
+      type: "evidence_uploaded",
+      title: "Evidence uploaded",
+      detail: e.originalName,
+      occurredAt: e.uploadedAt.toISOString(),
+    });
+  }
+
+  activities.sort((x, y) => new Date(y.occurredAt).getTime() - new Date(x.occurredAt).getTime());
+  const recentActivity = activities.slice(0, 10);
+
+  const assessments: DashboardAssessmentSummary[] = assessmentRows.map((a) => {
+    const items = a.items as ItemWithControlFramework[];
+    const computed = roundScore(weightedScorePercent(items));
+    const score =
+      a.score !== null && a.score !== undefined
+        ? roundScore(Number(a.score))
+        : items.length > 0
+          ? computed
+          : null;
+
+    return {
+      id: a.id,
+      organizationName: a.organization.productName,
+      status: a.status,
+      score,
+      updatedAt: a.updatedAt.toISOString(),
+      frameworkScores: frameworkScoresFromItems(items),
+    };
+  });
+
+  return {
+    totalAssessments,
+    averageScore,
+    criticalGaps,
+    reportsGenerated,
+    recentActivity,
+    assessments,
+  };
+}
+
+export const getCachedDashboardData = unstable_cache(
+  async (userId: string) => buildDashboardData(userId),
+  ["dashboard"],
+  { revalidate: dashboardRevalidateSec },
+);

--- a/tests/dashboard.routes.test.ts
+++ b/tests/dashboard.routes.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {},
+}));
+
+vi.mock("@/lib/dashboard-data", () => ({
+  getCachedDashboardData: vi.fn(),
+}));
+
+import { GET } from "@/app/api/dashboard/route";
+import * as authHelpers from "@/lib/auth-helpers";
+import * as dashboardData from "@/lib/dashboard-data";
+import type { DashboardApiData } from "@/types/dashboard";
+
+const mockDashboardPayload: DashboardApiData = {
+  totalAssessments: 1,
+  averageScore: 85,
+  criticalGaps: 2,
+  reportsGenerated: 0,
+  recentActivity: [],
+  assessments: [],
+};
+
+const dashboardReq = () => new Request("http://localhost/api/dashboard");
+
+describe("Dashboard API", () => {
+  const session = { user: { id: "user_1", role: "USER" as const } };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.spyOn(authHelpers, "requireAuth").mockResolvedValue(session as never);
+    vi.mocked(dashboardData.getCachedDashboardData).mockResolvedValue(mockDashboardPayload);
+  });
+
+  it("returns dashboard data for authenticated user", async () => {
+    const res = (await GET(dashboardReq())) as Response;
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(json.data.totalAssessments).toBe(1);
+    expect(json.data.averageScore).toBe(85);
+    expect(dashboardData.getCachedDashboardData).toHaveBeenCalledWith("user_1");
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    vi.spyOn(authHelpers, "requireAuth").mockRejectedValue(new Error("401: Unauthorized"));
+
+    const res = (await GET(dashboardReq())) as Response;
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/types/dashboard.ts
+++ b/types/dashboard.ts
@@ -1,0 +1,39 @@
+/** Payload inside `successResponse` `data` for GET /api/dashboard */
+
+export type DashboardActivityType =
+  | "report_generated"
+  | "assessment_created"
+  | "assessment_updated"
+  | "evidence_uploaded";
+
+export interface DashboardActivityItem {
+  id: string;
+  type: DashboardActivityType;
+  title: string;
+  detail: string;
+  occurredAt: string;
+}
+
+export interface DashboardFrameworkScore {
+  frameworkCode: string;
+  frameworkName: string;
+  score: number;
+}
+
+export interface DashboardAssessmentSummary {
+  id: string;
+  organizationName: string;
+  status: string;
+  score: number | null;
+  updatedAt: string;
+  frameworkScores: DashboardFrameworkScore[];
+}
+
+export interface DashboardApiData {
+  totalAssessments: number;
+  averageScore: number;
+  criticalGaps: number;
+  reportsGenerated: number;
+  recentActivity: DashboardActivityItem[];
+  assessments: DashboardAssessmentSummary[];
+}


### PR DESCRIPTION
Implemented GET /api/dashboard with:
- Aggregated metrics (total assessments, avg score, critical gaps, reports)
- Recent activity (last 10)
- Assessment summaries with framework JOIN
- Optimized queries using Promise.all
- Added caching (revalidate = 60)