### PR TITLE
feat/be1/assessment creation API

### DIFF
--- a/app/api/assessments/[id]/route.ts
+++ b/app/api/assessments/[id]/route.ts
@@ -1,0 +1,40 @@
+import { withErrorHandler } from "@/lib/api-handler";
+import { notFoundResponse, successResponse } from "@/lib/api-helpers";
+import { requireAuth } from "@/lib/auth-helpers";
+import { prisma } from "@/lib/prisma";
+
+interface RouteContext {
+  params: {
+    id: string;
+  };
+}
+
+export const GET = withErrorHandler(async (req: Request, { params }: RouteContext) => {
+  void req;
+  const session = await requireAuth();
+  const { id } = params;
+
+  const assessment = await prisma.assessment.findFirst({
+    where: {
+      id,
+      userId: session.user.id,
+    },
+    include: {
+      items: {
+        include: {
+          control: {
+            include: {
+              framework: true,
+            },
+          },
+        },
+      },
+    },
+  });
+
+  if (!assessment) {
+    return notFoundResponse("Assessment not found");
+  }
+
+  return successResponse(assessment, 200);
+});

--- a/app/api/assessments/route.ts
+++ b/app/api/assessments/route.ts
@@ -1,0 +1,118 @@
+import { withErrorHandler } from "@/lib/api-handler";
+import {
+  errorResponse,
+  notFoundResponse,
+  successResponse,
+  validationErrorResponse,
+} from "@/lib/api-helpers";
+import { requireAuth } from "@/lib/auth-helpers";
+import { prisma } from "@/lib/prisma";
+import { createAssessmentSchema } from "@/lib/validations/assessment";
+
+export const POST = withErrorHandler(async (req: Request) => {
+  const session = await requireAuth();
+
+  const body = await req.json();
+  const parsed = createAssessmentSchema.safeParse(body);
+
+  if (!parsed.success) {
+    return validationErrorResponse(parsed.error.format());
+  }
+
+  const { organizationId, frameworkIds } = parsed.data;
+  const uniqueFrameworkIds = [...new Set(frameworkIds)];
+
+  const organization = await prisma.organization.findUnique({
+    where: { id: organizationId },
+    select: {
+      id: true,
+      userId: true,
+    },
+  });
+
+  if (!organization) {
+    return notFoundResponse("Organization not found");
+  }
+
+  if (organization.userId !== session.user.id) {
+    throw new Error("403: Forbidden");
+  }
+
+  const frameworks = await prisma.framework.findMany({
+    where: {
+      id: {
+        in: uniqueFrameworkIds,
+      },
+    },
+    select: {
+      id: true,
+    },
+  });
+
+  if (frameworks.length !== uniqueFrameworkIds.length) {
+    return errorResponse("One or more frameworks were not found", 400);
+  }
+
+  const controls = await prisma.control.findMany({
+    where: {
+      frameworkId: {
+        in: uniqueFrameworkIds,
+      },
+    },
+    select: {
+      id: true,
+    },
+  });
+
+  if (controls.length === 0) {
+    return errorResponse("No controls found for selected frameworks", 400);
+  }
+
+  const created = await prisma.$transaction(async (tx) => {
+    const assessment = await tx.assessment.create({
+      data: {
+        userId: session.user.id,
+        organizationId,
+      },
+      select: {
+        id: true,
+      },
+    });
+
+    const itemResult = await tx.assessmentItem.createMany({
+      data: controls.map((control) => ({
+        assessmentId: assessment.id,
+        controlId: control.id,
+      })),
+    });
+
+    return {
+      assessmentId: assessment.id,
+      totalItems: itemResult.count,
+    };
+  });
+
+  return successResponse(created, 201);
+});
+
+export const GET = withErrorHandler(async () => {
+  const session = await requireAuth();
+
+  const assessments = await prisma.assessment.findMany({
+    where: {
+      userId: session.user.id,
+    },
+    orderBy: {
+      createdAt: "desc",
+    },
+    select: {
+      id: true,
+      status: true,
+      score: true,
+      createdAt: true,
+      organizationId: true,
+    },
+  });
+
+  return successResponse(assessments, 200);
+});

--- a/tests/assessments.routes.test.ts
+++ b/tests/assessments.routes.test.ts
@@ -1,0 +1,252 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as authHelpers from "@/lib/auth-helpers";
+import { prisma } from "@/lib/prisma";
+import { GET as getAssessmentById } from "@/app/api/assessments/[id]/route";
+import { GET as getAssessments, POST as createAssessment } from "@/app/api/assessments/route";
+
+vi.mock("@/lib/prisma", () => {
+  return {
+    prisma: {
+      organization: {
+        findUnique: vi.fn(),
+      },
+      framework: {
+        findMany: vi.fn(),
+      },
+      control: {
+        findMany: vi.fn(),
+      },
+      assessment: {
+        create: vi.fn(),
+        findMany: vi.fn(),
+        findFirst: vi.fn(),
+      },
+      assessmentItem: {
+        createMany: vi.fn(),
+      },
+      $transaction: vi.fn(),
+    },
+  };
+});
+
+describe("Assessments API routes", () => {
+  const session = { user: { id: "user_1", role: "USER" } };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.spyOn(authHelpers, "requireAuth").mockResolvedValue(session as never);
+    vi.spyOn(prisma, "$transaction").mockImplementation(async (callback) => {
+      return await callback(prisma as never);
+    });
+  });
+
+  it("creates an assessment with deduplicated framework IDs and bulk items", async () => {
+    vi.spyOn(prisma.organization, "findUnique").mockResolvedValue({
+      id: "org_1",
+      userId: "user_1",
+    } as never);
+
+    vi.spyOn(prisma.framework, "findMany").mockResolvedValue([
+      { id: "fw_1" },
+      { id: "fw_2" },
+    ] as never);
+
+    vi.spyOn(prisma.control, "findMany").mockResolvedValue([
+      { id: "ctrl_1" },
+      { id: "ctrl_2" },
+      { id: "ctrl_3" },
+    ] as never);
+
+    vi.spyOn(prisma.assessment, "create").mockResolvedValue({ id: "asm_1" } as never);
+    vi.spyOn(prisma.assessmentItem, "createMany").mockResolvedValue({ count: 3 } as never);
+
+    const req = new Request("http://localhost/api/assessments", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        organizationId: "cm8abcde0000000000000001",
+        frameworkIds: [
+          "cm8abcde0000000000000002",
+          "cm8abcde0000000000000002",
+          "cm8abcde0000000000000003",
+        ],
+      }),
+    });
+
+    const res = (await createAssessment(req)) as Response;
+    const json = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(json.success).toBe(true);
+    expect(json.data.assessmentId).toBe("asm_1");
+    expect(json.data.totalItems).toBe(3);
+    expect(prisma.framework.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          id: {
+            in: ["cm8abcde0000000000000002", "cm8abcde0000000000000003"],
+          },
+        },
+      }),
+    );
+    expect(prisma.assessmentItem.createMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: [
+          { assessmentId: "asm_1", controlId: "ctrl_1" },
+          { assessmentId: "asm_1", controlId: "ctrl_2" },
+          { assessmentId: "asm_1", controlId: "ctrl_3" },
+        ],
+      }),
+    );
+  });
+
+  it("returns 400 when selected frameworks have no controls", async () => {
+    vi.spyOn(prisma.organization, "findUnique").mockResolvedValue({
+      id: "org_1",
+      userId: "user_1",
+    } as never);
+    vi.spyOn(prisma.framework, "findMany").mockResolvedValue([{ id: "fw_1" }] as never);
+    vi.spyOn(prisma.control, "findMany").mockResolvedValue([] as never);
+
+    const req = new Request("http://localhost/api/assessments", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        organizationId: "cm8abcde0000000000000001",
+        frameworkIds: ["cm8abcde0000000000000002"],
+      }),
+    });
+
+    const res = (await createAssessment(req)) as Response;
+
+    expect(res.status).toBe(400);
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when organization is not owned by current user", async () => {
+    vi.spyOn(prisma.organization, "findUnique").mockResolvedValue({
+      id: "org_1",
+      userId: "user_2",
+    } as never);
+
+    const req = new Request("http://localhost/api/assessments", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        organizationId: "cm8abcde0000000000000001",
+        frameworkIds: ["cm8abcde0000000000000002"],
+      }),
+    });
+
+    const res = (await createAssessment(req)) as Response;
+
+    expect(res.status).toBe(403);
+  });
+
+  it("returns all assessments for current user", async () => {
+    vi.spyOn(prisma.assessment, "findMany").mockResolvedValue([
+      {
+        id: "asm_2",
+        status: "COMPLETED",
+        score: 92,
+        createdAt: new Date("2026-04-01T00:00:00.000Z"),
+        organizationId: "org_2",
+      },
+      {
+        id: "asm_1",
+        status: "IN_PROGRESS",
+        score: null,
+        createdAt: new Date("2026-03-31T00:00:00.000Z"),
+        organizationId: "org_1",
+      },
+    ] as never);
+
+    const req = new Request("http://localhost/api/assessments", {
+      method: "GET",
+    });
+
+    const res = (await getAssessments(req)) as Response;
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(json.data).toHaveLength(2);
+    expect(prisma.assessment.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { userId: "user_1" },
+        orderBy: { createdAt: "desc" },
+      }),
+    );
+  });
+
+  it("returns assessment detail with items, control, and framework", async () => {
+    vi.spyOn(prisma.assessment, "findFirst").mockResolvedValue({
+      id: "asm_1",
+      userId: "user_1",
+      organizationId: "org_1",
+      status: "IN_PROGRESS",
+      score: null,
+      createdAt: new Date("2026-03-31T00:00:00.000Z"),
+      updatedAt: new Date("2026-03-31T00:00:00.000Z"),
+      completedAt: null,
+      items: [
+        {
+          id: "item_1",
+          control: {
+            id: "ctrl_1",
+            code: "GDPR-1",
+            title: "Control One",
+            framework: {
+              id: "fw_1",
+              code: "GDPR",
+              name: "GDPR",
+            },
+          },
+        },
+      ],
+    } as never);
+
+    const req = new Request("http://localhost/api/assessments/asm_1", {
+      method: "GET",
+    });
+
+    const res = (await getAssessmentById(req, { params: { id: "asm_1" } })) as Response;
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(json.data.id).toBe("asm_1");
+    expect(json.data.items[0].control.framework.code).toBe("GDPR");
+  });
+
+  it("returns 404 for missing assessment detail", async () => {
+    vi.spyOn(prisma.assessment, "findFirst").mockResolvedValue(null as never);
+
+    const req = new Request("http://localhost/api/assessments/missing", {
+      method: "GET",
+    });
+
+    const res = (await getAssessmentById(req, { params: { id: "missing" } })) as Response;
+
+    expect(res.status).toBe(404);
+  });
+
+  it("maps auth failures to 401", async () => {
+    vi.spyOn(authHelpers, "requireAuth").mockRejectedValue(new Error("401: Unauthorized"));
+
+    const req = new Request("http://localhost/api/assessments", {
+      method: "GET",
+    });
+
+    const res = (await getAssessments(req)) as Response;
+
+    expect(res.status).toBe(401);
+  });
+});


### PR DESCRIPTION
## Description

Implements Task 3.4 - Assessment Creation API.
Adds endpoints to create assessments with bulk-generated items from selected frameworks, along with list and detail retrieval APIs.

---

## Type of Change

* [x] feat: New feature

* [ ] fix: Bug fix

* [ ] refactor: Code refactoring

* [ ] docs: Documentation update

* [ ] test: Adding or updating tests

* [ ] chore: Build/dependency updates

* [ ] perf: Performance improvement

* [ ] hotfix: Urgent production fix

---

## Related Issues

Closes Task 3.4

---

## Changes Made

* Added POST `/api/assessments` to create assessment with bulk items
* Added GET `/api/assessments` to list user assessments
* Added GET `/api/assessments/[id]` for full assessment detail
* Implemented Prisma transaction for atomic creation
* Handled edge cases (no controls, invalid frameworks, unauthorized access)
* Included control + framework data in detail endpoint (no N+1)
* Added integration tests for create, list, and detail flows

---

## Testing

* [x] Unit tests added/updated

* [x] Integration tests added/updated

* [ ] E2E tests added/updated

* [x] Manual testing performed

* [x] Tested on dev environment

---

## Screenshots (if applicable)

N/A

---

## Checklist

* [x] My code follows the project's coding standards

* [x] I have performed a self-review of my code

* [x] I have commented my code where necessary

* [ ] I have updated the documentation (if needed)

* [x] My changes generate no new warnings

* [x] I have added tests that prove my fix/feature works

* [x] New and existing tests pass locally

* [ ] Any dependent changes have been merged

---

