### PR TITLE
feat/be1/assessment-items-api

### DIFF
--- a/app/api/assessments/[id]/items/[itemId]/route.ts
+++ b/app/api/assessments/[id]/items/[itemId]/route.ts
@@ -41,47 +41,18 @@ export const PATCH = withErrorHandler(async (req: Request, { params }: RouteCont
     return validationErrorResponse(parsed.error.format());
   }
 
-  const startedAt = Date.now();
-
   const data = await prisma.$transaction(async (tx) => {
-    const updatedItem = await tx.assessmentItem.update({
+    await tx.assessmentItem.update({
       where: {
         id: itemId,
       },
       data: parsed.data,
-      select: {
-        id: true,
-        assessmentId: true,
-        controlId: true,
-        status: true,
-        comments: true,
-        owner: true,
-        targetDate: true,
-        remarks: true,
-        evidenceNotes: true,
-        updatedAt: true,
-      },
     });
 
     const score = await recalculateAssessmentScore(assessmentId, tx);
 
-    return {
-      item: updatedItem,
-      score,
-    };
+    return score;
   });
 
-  const calculationDurationMs = Date.now() - startedAt;
-
-  return successResponse(
-    {
-      assessmentId: data.score.assessmentId,
-      score: data.score.score,
-      numerator: data.score.numerator,
-      denominator: data.score.denominator,
-      item: data.item,
-      calculationDurationMs,
-    },
-    200,
-  );
+  return successResponse({ score: data.score }, 200);
 });

--- a/app/api/assessments/[id]/items/route.ts
+++ b/app/api/assessments/[id]/items/route.ts
@@ -1,0 +1,164 @@
+import { Prisma } from "@prisma/client";
+
+import { withErrorHandler } from "@/lib/api-handler";
+import { notFoundResponse, successResponse, validationErrorResponse } from "@/lib/api-helpers";
+import { requireAuth } from "@/lib/auth-helpers";
+import { prisma } from "@/lib/prisma";
+import { assessmentItemsListQuerySchema } from "@/lib/validations/assessment";
+
+interface RouteContext {
+  params: {
+    id: string;
+  };
+}
+
+function buildOrderBy(sortBy: string, sortOrder: Prisma.SortOrder) {
+  if (sortBy === "updatedAt") {
+    return [{ updatedAt: sortOrder } satisfies Prisma.AssessmentItemOrderByWithRelationInput];
+  }
+
+  if (sortBy === "createdAt") {
+    return [{ createdAt: sortOrder } satisfies Prisma.AssessmentItemOrderByWithRelationInput];
+  }
+
+  if (sortBy === "status") {
+    return [
+      { status: sortOrder } satisfies Prisma.AssessmentItemOrderByWithRelationInput,
+      { updatedAt: "desc" } satisfies Prisma.AssessmentItemOrderByWithRelationInput,
+    ];
+  }
+
+  if (sortBy === "code") {
+    return [
+      { control: { code: sortOrder } } satisfies Prisma.AssessmentItemOrderByWithRelationInput,
+      { updatedAt: "desc" } satisfies Prisma.AssessmentItemOrderByWithRelationInput,
+    ];
+  }
+
+  // Severity uses enum declaration order (LOW, MEDIUM, HIGH, CRITICAL).
+  // Descending returns CRITICAL first, then HIGH, MEDIUM, LOW.
+  return [
+    { control: { severity: sortOrder } } satisfies Prisma.AssessmentItemOrderByWithRelationInput,
+    { updatedAt: "desc" } satisfies Prisma.AssessmentItemOrderByWithRelationInput,
+  ];
+}
+
+export const GET = withErrorHandler(async (req: Request, { params }: RouteContext) => {
+  const session = await requireAuth();
+  const { id: assessmentId } = params;
+
+  const ownedAssessment = await prisma.assessment.findFirst({
+    where: {
+      id: assessmentId,
+      userId: session.user.id,
+    },
+    select: {
+      id: true,
+    },
+  });
+
+  if (!ownedAssessment) {
+    return notFoundResponse("Assessment not found");
+  }
+
+  const url = new URL(req.url);
+  const raw = Object.fromEntries(url.searchParams.entries());
+  const parsed = assessmentItemsListQuerySchema.safeParse(raw);
+
+  if (!parsed.success) {
+    return validationErrorResponse(parsed.error.format());
+  }
+
+  const { page, limit, status, framework, severity, search, sortBy, sortOrder } = parsed.data;
+
+  const where: Prisma.AssessmentItemWhereInput = {
+    assessmentId,
+    ...(status ? { status } : {}),
+    ...(framework || severity
+      ? {
+          control: {
+            ...(framework ? { frameworkId: framework } : {}),
+            ...(severity ? { severity } : {}),
+          },
+        }
+      : {}),
+    ...(search
+      ? {
+          OR: [
+            {
+              comments: {
+                contains: search,
+                mode: "insensitive",
+              },
+            },
+            {
+              control: {
+                code: {
+                  contains: search,
+                  mode: "insensitive",
+                },
+              },
+            },
+            {
+              control: {
+                title: {
+                  contains: search,
+                  mode: "insensitive",
+                },
+              },
+            },
+          ],
+        }
+      : {}),
+  };
+
+  const skip = (page - 1) * limit;
+  const orderBy = buildOrderBy(sortBy, sortOrder);
+
+  const [items, total] = await Promise.all([
+    prisma.assessmentItem.findMany({
+      where,
+      skip,
+      take: limit,
+      orderBy,
+      select: {
+        id: true,
+        status: true,
+        comments: true,
+        createdAt: true,
+        updatedAt: true,
+        control: {
+          select: {
+            id: true,
+            code: true,
+            title: true,
+            severity: true,
+            weight: true,
+            framework: {
+              select: {
+                id: true,
+                code: true,
+                name: true,
+              },
+            },
+          },
+        },
+      },
+    }),
+    prisma.assessmentItem.count({ where }),
+  ]);
+
+  const totalPages = Math.max(1, Math.ceil(total / limit));
+
+  return successResponse({
+    items,
+    meta: {
+      total,
+      page,
+      limit,
+      totalPages,
+      hasNextPage: page < totalPages,
+      hasPrevPage: page > 1,
+    },
+  });
+});

--- a/app/api/assessments/[id]/score/route.ts
+++ b/app/api/assessments/[id]/score/route.ts
@@ -1,6 +1,6 @@
 import { withErrorHandler } from "@/lib/api-handler";
 import { notFoundResponse, successResponse } from "@/lib/api-helpers";
-import { recalculateAssessmentScore } from "@/lib/assessment-score";
+import { getFrameworkScoresForAssessment } from "@/lib/assessment-score";
 import { requireAuth } from "@/lib/auth-helpers";
 import { prisma } from "@/lib/prisma";
 
@@ -10,7 +10,11 @@ interface RouteContext {
   };
 }
 
-export const POST = withErrorHandler(async (req: Request, { params }: RouteContext) => {
+function roundScore(score: number): number {
+  return Math.round(score * 10) / 10;
+}
+
+export const GET = withErrorHandler(async (req: Request, { params }: RouteContext) => {
   void req;
   const session = await requireAuth();
   const { id } = params;
@@ -22,6 +26,7 @@ export const POST = withErrorHandler(async (req: Request, { params }: RouteConte
     },
     select: {
       id: true,
+      score: true,
     },
   });
 
@@ -29,14 +34,13 @@ export const POST = withErrorHandler(async (req: Request, { params }: RouteConte
     return notFoundResponse("Assessment not found");
   }
 
-  const startedAt = Date.now();
-  const scoreResult = await recalculateAssessmentScore(id);
-  const calculationDurationMs = Date.now() - startedAt;
+  const frameworkScores = await getFrameworkScoresForAssessment(id);
 
   return successResponse(
     {
-      ...scoreResult,
-      calculationDurationMs,
+      assessmentId: ownedAssessment.id,
+      score: roundScore(Number(ownedAssessment.score ?? 0)),
+      frameworkScores,
     },
     200,
   );

--- a/lib/assessment-score.ts
+++ b/lib/assessment-score.ts
@@ -1,84 +1,160 @@
-import { Prisma, PrismaClient } from "@prisma/client";
+import { ItemStatus, Prisma, PrismaClient } from "@prisma/client";
 
 import { prisma } from "@/lib/prisma";
 
-interface AssessmentScoreRow {
-  id: string;
-  score: number | null;
-  numerator: number;
-  denominator: number;
+export interface ScoreItemRow {
+  status: ItemStatus;
+  control: {
+    weight: number;
+    frameworkId: string;
+    framework: {
+      id: string;
+      code: string;
+      name: string;
+    };
+  };
+}
+
+export interface FrameworkScore {
+  frameworkId: string;
+  frameworkCode: string;
+  frameworkName: string;
+  score: number;
 }
 
 export interface AssessmentScoreResult {
   assessmentId: string;
   score: number;
-  numerator: number;
-  denominator: number;
+  frameworkScores: FrameworkScore[];
 }
 
 type ScoreQueryExecutor = PrismaClient | Prisma.TransactionClient;
+
+export function roundScore(score: number): number {
+  return Math.round(score * 10) / 10;
+}
+
+export function statusFactor(status: ItemStatus): number | null {
+  if (status === "COMPLIANT") {
+    return 1;
+  }
+
+  if (status === "PARTIALLY_COMPLIANT") {
+    return 0.5;
+  }
+
+  if (status === "NOT_APPLICABLE") {
+    return null;
+  }
+
+  return 0;
+}
+
+export function computeOverallScore(rows: ScoreItemRow[]): number {
+  let numerator = 0;
+  let denominator = 0;
+
+  for (const row of rows) {
+    const factor = statusFactor(row.status);
+
+    if (factor === null) {
+      continue;
+    }
+
+    const weight = row.control.weight;
+    denominator += weight;
+    numerator += weight * factor;
+  }
+
+  if (denominator <= 0) {
+    return 0;
+  }
+
+  return roundScore((numerator / denominator) * 100);
+}
+
+export function computeFrameworkScores(rows: ScoreItemRow[]): FrameworkScore[] {
+  const grouped = new Map<string, ScoreItemRow[]>();
+
+  for (const row of rows) {
+    const key = row.control.frameworkId;
+    const list = grouped.get(key) ?? [];
+    list.push(row);
+    grouped.set(key, list);
+  }
+
+  const scores: FrameworkScore[] = [];
+
+  for (const group of grouped.values()) {
+    const framework = group[0].control.framework;
+    scores.push({
+      frameworkId: framework.id,
+      frameworkCode: framework.code,
+      frameworkName: framework.name,
+      score: computeOverallScore(group),
+    });
+  }
+
+  scores.sort((a, b) => a.frameworkCode.localeCompare(b.frameworkCode));
+
+  return scores;
+}
+
+async function fetchScoreRows(
+  assessmentId: string,
+  db: ScoreQueryExecutor,
+): Promise<ScoreItemRow[]> {
+  return await db.assessmentItem.findMany({
+    where: {
+      assessmentId,
+    },
+    select: {
+      status: true,
+      control: {
+        select: {
+          weight: true,
+          frameworkId: true,
+          framework: {
+            select: {
+              id: true,
+              code: true,
+              name: true,
+            },
+          },
+        },
+      },
+    },
+  });
+}
 
 export async function recalculateAssessmentScore(
   assessmentId: string,
   db: ScoreQueryExecutor = prisma,
 ): Promise<AssessmentScoreResult> {
-  const rows = await db.$queryRaw<AssessmentScoreRow[]>(Prisma.sql`
-    WITH totals AS (
-      SELECT
-        COALESCE(
-          SUM(
-            CASE
-              WHEN ai.status <> 'NOT_APPLICABLE'::"ItemStatus" AND c."isGateway" = FALSE THEN c.weight
-              ELSE 0
-            END
-          ),
-          0
-        )::double precision AS denominator,
-        COALESCE(
-          SUM(
-            CASE
-              WHEN c."isGateway" = FALSE AND ai.status = 'COMPLIANT'::"ItemStatus" THEN c.weight
-              WHEN c."isGateway" = FALSE AND ai.status = 'PARTIALLY_COMPLIANT'::"ItemStatus" THEN c.weight * 0.5
-              ELSE 0
-            END
-          ),
-          0
-        )::double precision AS numerator
-      FROM "assessment_items" ai
-      JOIN "controls" c ON c.id = ai."controlId"
-      WHERE ai."assessmentId" = ${assessmentId}
-    ),
-    updated AS (
-      UPDATE "assessments" a
-      SET
-        "score" = CASE
-          WHEN t.denominator > 0 THEN (t.numerator / t.denominator) * 100
-          ELSE 0
-        END,
-        "updatedAt" = NOW()
-      FROM totals t
-      WHERE a.id = ${assessmentId}
-      RETURNING a.id, a."score"
-    )
-    SELECT
-      u.id,
-      u."score",
-      t.numerator,
-      t.denominator
-    FROM updated u
-    CROSS JOIN totals t
-  `);
+  const rows = await fetchScoreRows(assessmentId, db);
+  const score = computeOverallScore(rows);
+  const frameworkScores = computeFrameworkScores(rows);
 
-  if (rows.length === 0) {
+  const updated = await db.assessment.updateMany({
+    where: { id: assessmentId },
+    data: { score },
+  });
+
+  if (updated.count === 0) {
     throw new Error("404: Assessment not found");
   }
 
-  const row = rows[0];
-
   return {
-    assessmentId: row.id,
-    score: Number(row.score ?? 0),
-    numerator: Number(row.numerator),
-    denominator: Number(row.denominator),
+    assessmentId,
+    score,
+    frameworkScores,
   };
+}
+
+export async function getFrameworkScoresForAssessment(
+  assessmentId: string,
+  db: ScoreQueryExecutor = prisma,
+): Promise<FrameworkScore[]> {
+  const rows = await fetchScoreRows(assessmentId, db);
+  return computeFrameworkScores(rows);
 }

--- a/lib/validations/assessment.ts
+++ b/lib/validations/assessment.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { Severity } from "@prisma/client";
 
 export const createAssessmentSchema = z.object({
   organizationId: z.cuid(),
@@ -28,3 +29,16 @@ export const updateAssessmentItemSchema = z
   .refine((value) => Object.keys(value).length > 0, {
     message: "At least one field must be provided",
   });
+
+export const assessmentItemsListQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(50),
+  status: assessmentItemStatusSchema.optional(),
+  framework: z.cuid().optional(),
+  severity: z.nativeEnum(Severity).optional(),
+  search: z.string().trim().max(200).optional(),
+  sortBy: z.enum(["severity", "updatedAt", "createdAt", "status", "code"]).default("severity"),
+  sortOrder: z.enum(["asc", "desc"]).default("desc"),
+});
+
+export type AssessmentItemsListQuery = z.infer<typeof assessmentItemsListQuerySchema>;

--- a/tests/assessment-item.routes.test.ts
+++ b/tests/assessment-item.routes.test.ts
@@ -7,11 +7,14 @@ import { PATCH as assessmentItemPatch } from "@/app/api/assessments/[id]/items/[
 vi.mock("@/lib/prisma", () => {
   return {
     prisma: {
+      assessment: {
+        updateMany: vi.fn(),
+      },
       assessmentItem: {
         findFirst: vi.fn(),
+        findMany: vi.fn(),
         update: vi.fn(),
       },
-      $queryRaw: vi.fn(),
       $transaction: vi.fn(),
     },
   };
@@ -28,7 +31,7 @@ describe("Assessment item API route", () => {
     });
   });
 
-  it("updates assessment item and recalculates score", async () => {
+  it("updates assessment item and recalculates + persists score", async () => {
     vi.spyOn(prisma.assessmentItem, "findFirst").mockResolvedValue({
       id: "item_1",
       assessmentId: "asm_1",
@@ -36,25 +39,35 @@ describe("Assessment item API route", () => {
 
     vi.spyOn(prisma.assessmentItem, "update").mockResolvedValue({
       id: "item_1",
-      assessmentId: "asm_1",
-      controlId: "ctrl_1",
-      status: "COMPLIANT",
-      comments: "Updated",
-      owner: null,
-      targetDate: null,
-      remarks: null,
-      evidenceNotes: null,
-      updatedAt: new Date("2026-03-29T00:00:00.000Z"),
     } as never);
 
-    vi.spyOn(prisma, "$queryRaw").mockResolvedValue([
+    vi.spyOn(prisma.assessmentItem, "findMany").mockResolvedValue([
       {
-        id: "asm_1",
-        score: 91.5,
-        numerator: 183,
-        denominator: 200,
+        status: "COMPLIANT",
+        control: {
+          weight: 1,
+          frameworkId: "fw_1",
+          framework: {
+            id: "fw_1",
+            code: "GDPR",
+            name: "GDPR",
+          },
+        },
+      },
+      {
+        status: "NOT_COMPLIANT",
+        control: {
+          weight: 1,
+          frameworkId: "fw_1",
+          framework: {
+            id: "fw_1",
+            code: "GDPR",
+            name: "GDPR",
+          },
+        },
       },
     ] as never);
+    vi.spyOn(prisma.assessment, "updateMany").mockResolvedValue({ count: 1 } as never);
 
     const req = new Request("http://localhost/api/assessments/asm_1/items/item_1", {
       method: "PATCH",
@@ -75,10 +88,11 @@ describe("Assessment item API route", () => {
 
     expect(res.status).toBe(200);
     expect(json.success).toBe(true);
-    expect(json.data.assessmentId).toBe("asm_1");
-    expect(json.data.score).toBe(91.5);
-    expect(json.data.item.id).toBe("item_1");
-    expect(typeof json.data.calculationDurationMs).toBe("number");
+    expect(json.data).toEqual({ score: 50 });
+    expect(prisma.assessment.updateMany).toHaveBeenCalledWith({
+      where: { id: "asm_1" },
+      data: { score: 50 },
+    });
   });
 
   it("returns 404 when assessment item is not owned by user", async () => {

--- a/tests/assessment-items-list.routes.test.ts
+++ b/tests/assessment-items-list.routes.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as authHelpers from "@/lib/auth-helpers";
+import { GET as listAssessmentItems } from "@/app/api/assessments/[id]/items/route";
+import { prisma } from "@/lib/prisma";
+
+vi.mock("@/lib/prisma", () => {
+  return {
+    prisma: {
+      assessment: {
+        findFirst: vi.fn(),
+      },
+      assessmentItem: {
+        findMany: vi.fn(),
+        count: vi.fn(),
+      },
+    },
+  };
+});
+
+describe("Assessment items list API route", () => {
+  const session = { user: { id: "user_1", role: "USER" } };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.spyOn(authHelpers, "requireAuth").mockResolvedValue(session as never);
+  });
+
+  it("returns paginated list with defaults", async () => {
+    vi.spyOn(prisma.assessment, "findFirst").mockResolvedValue({ id: "asm_1" } as never);
+    vi.spyOn(prisma.assessmentItem, "findMany").mockResolvedValue([
+      {
+        id: "item_1",
+        status: "NOT_COMPLIANT",
+        comments: "Missing policy",
+        owner: null,
+        targetDate: null,
+        remarks: null,
+        evidenceNotes: null,
+        createdAt: new Date("2026-04-01T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-02T00:00:00.000Z"),
+        control: {
+          id: "ctrl_1",
+          code: "GDPR-1",
+          title: "Data policy",
+          severity: "CRITICAL",
+          weight: 1,
+          framework: {
+            id: "fw_1",
+            code: "GDPR",
+            name: "GDPR",
+          },
+        },
+      },
+    ] as never);
+    vi.spyOn(prisma.assessmentItem, "count").mockResolvedValue(1);
+
+    const req = new Request("http://localhost/api/assessments/asm_1/items", { method: "GET" });
+    const res = (await listAssessmentItems(req, { params: { id: "asm_1" } })) as Response;
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(json.data.items).toHaveLength(1);
+    expect(json.data.meta).toEqual({
+      total: 1,
+      page: 1,
+      limit: 50,
+      totalPages: 1,
+      hasNextPage: false,
+      hasPrevPage: false,
+    });
+
+    expect(prisma.assessmentItem.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        skip: 0,
+        take: 50,
+        orderBy: [{ control: { severity: "desc" } }, { updatedAt: "desc" }],
+      }),
+    );
+  });
+
+  it("applies filters and search on code/title/comments", async () => {
+    vi.spyOn(prisma.assessment, "findFirst").mockResolvedValue({ id: "asm_1" } as never);
+    vi.spyOn(prisma.assessmentItem, "findMany").mockResolvedValue([] as never);
+    vi.spyOn(prisma.assessmentItem, "count").mockResolvedValue(0);
+
+    const req = new Request(
+      "http://localhost/api/assessments/asm_1/items?status=NOT_COMPLIANT&framework=ckfw000000000000000000000&severity=CRITICAL&search=policy&page=2&limit=10&sortBy=updatedAt&sortOrder=asc",
+      { method: "GET" },
+    );
+
+    const res = (await listAssessmentItems(req, { params: { id: "asm_1" } })) as Response;
+
+    expect(res.status).toBe(200);
+    expect(prisma.assessmentItem.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          assessmentId: "asm_1",
+          status: "NOT_COMPLIANT",
+          control: {
+            frameworkId: "ckfw000000000000000000000",
+            severity: "CRITICAL",
+          },
+          OR: [
+            { comments: { contains: "policy", mode: "insensitive" } },
+            { control: { code: { contains: "policy", mode: "insensitive" } } },
+            { control: { title: { contains: "policy", mode: "insensitive" } } },
+          ],
+        },
+        skip: 10,
+        take: 10,
+        orderBy: [{ updatedAt: "asc" }],
+      }),
+    );
+  });
+
+  it("returns 404 when assessment is not owned by user", async () => {
+    vi.spyOn(prisma.assessment, "findFirst").mockResolvedValue(null as never);
+
+    const req = new Request("http://localhost/api/assessments/asm_404/items", { method: "GET" });
+    const res = (await listAssessmentItems(req, { params: { id: "asm_404" } })) as Response;
+
+    expect(res.status).toBe(404);
+    expect(prisma.assessmentItem.findMany).not.toHaveBeenCalled();
+  });
+
+  it("returns 422 for invalid query", async () => {
+    vi.spyOn(prisma.assessment, "findFirst").mockResolvedValue({ id: "asm_1" } as never);
+
+    const req = new Request("http://localhost/api/assessments/asm_1/items?limit=1000", {
+      method: "GET",
+    });
+    const res = (await listAssessmentItems(req, { params: { id: "asm_1" } })) as Response;
+
+    expect(res.status).toBe(422);
+  });
+});

--- a/tests/assessment-score.logic.test.ts
+++ b/tests/assessment-score.logic.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/prisma", () => ({
+  prisma: {},
+}));
+
+import {
+  computeFrameworkScores,
+  computeOverallScore,
+  roundScore,
+  statusFactor,
+  type ScoreItemRow,
+} from "@/lib/assessment-score";
+
+function row(
+  status: ScoreItemRow["status"],
+  weight: number,
+  frameworkId: string,
+  frameworkCode: string,
+  frameworkName: string,
+): ScoreItemRow {
+  return {
+    status,
+    control: {
+      weight,
+      frameworkId,
+      framework: {
+        id: frameworkId,
+        code: frameworkCode,
+        name: frameworkName,
+      },
+    },
+  };
+}
+
+describe("Assessment scoring logic", () => {
+  it("maps status factors per PRD", () => {
+    expect(statusFactor("COMPLIANT")).toBe(1);
+    expect(statusFactor("PARTIALLY_COMPLIANT")).toBe(0.5);
+    expect(statusFactor("NOT_COMPLIANT")).toBe(0);
+    expect(statusFactor("NOT_STARTED")).toBe(0);
+    expect(statusFactor("NOT_APPLICABLE")).toBeNull();
+  });
+
+  it("excludes NOT_APPLICABLE from denominator", () => {
+    const rows: ScoreItemRow[] = [
+      row("COMPLIANT", 2, "fw1", "GDPR", "GDPR"),
+      row("NOT_APPLICABLE", 8, "fw1", "GDPR", "GDPR"),
+    ];
+
+    // (2*1.0)/(2) * 100 = 100
+    expect(computeOverallScore(rows)).toBe(100);
+  });
+
+  it("computes weighted mixed compliance correctly", () => {
+    const rows: ScoreItemRow[] = [
+      row("COMPLIANT", 2, "fw1", "GDPR", "GDPR"),
+      row("PARTIALLY_COMPLIANT", 4, "fw1", "GDPR", "GDPR"),
+      row("NOT_COMPLIANT", 4, "fw1", "GDPR", "GDPR"),
+    ];
+
+    // numerator = 2*1 + 4*0.5 + 4*0 = 4
+    // denominator = 10
+    // score = 40.0
+    expect(computeOverallScore(rows)).toBe(40);
+  });
+
+  it("returns 0 when denominator is zero", () => {
+    const rows: ScoreItemRow[] = [
+      row("NOT_APPLICABLE", 2, "fw1", "GDPR", "GDPR"),
+      row("NOT_APPLICABLE", 5, "fw1", "GDPR", "GDPR"),
+    ];
+
+    expect(computeOverallScore(rows)).toBe(0);
+  });
+
+  it("rounds to 1 decimal place", () => {
+    // 2/3*100 = 66.666...
+    const rows: ScoreItemRow[] = [
+      row("COMPLIANT", 2, "fw1", "GDPR", "GDPR"),
+      row("NOT_COMPLIANT", 1, "fw1", "GDPR", "GDPR"),
+    ];
+
+    expect(computeOverallScore(rows)).toBe(66.7);
+    expect(roundScore(66.666)).toBe(66.7);
+  });
+
+  it("computes per-framework scores and sorts by framework code", () => {
+    const rows: ScoreItemRow[] = [
+      row("PARTIALLY_COMPLIANT", 2, "fw_b", "PCI", "PCI DSS"),
+      row("COMPLIANT", 2, "fw_a", "GDPR", "GDPR"),
+      row("NOT_COMPLIANT", 2, "fw_a", "GDPR", "GDPR"),
+    ];
+
+    const frameworkScores = computeFrameworkScores(rows);
+
+    expect(frameworkScores).toEqual([
+      {
+        frameworkId: "fw_a",
+        frameworkCode: "GDPR",
+        frameworkName: "GDPR",
+        score: 50,
+      },
+      {
+        frameworkId: "fw_b",
+        frameworkCode: "PCI",
+        frameworkName: "PCI DSS",
+        score: 50,
+      },
+    ]);
+  });
+});

--- a/tests/assessment-score.routes.test.ts
+++ b/tests/assessment-score.routes.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { prisma } from "@/lib/prisma";
 import * as authHelpers from "@/lib/auth-helpers";
-import { POST as recalculateScorePost } from "@/app/api/assessments/[id]/score/route";
+import { GET as scoreGet } from "@/app/api/assessments/[id]/score/route";
 
 vi.mock("@/lib/prisma", () => {
   return {
@@ -10,7 +10,9 @@ vi.mock("@/lib/prisma", () => {
       assessment: {
         findFirst: vi.fn(),
       },
-      $queryRaw: vi.fn(),
+      assessmentItem: {
+        findMany: vi.fn(),
+      },
     },
   };
 });
@@ -23,52 +25,86 @@ describe("Assessment score API route", () => {
     vi.spyOn(authHelpers, "requireAuth").mockResolvedValue(session as never);
   });
 
-  it("recalculates score for owned assessment", async () => {
-    vi.spyOn(prisma.assessment, "findFirst").mockResolvedValue({ id: "asm_1" } as never);
-    vi.spyOn(prisma, "$queryRaw").mockResolvedValue([
+  it("returns stored score and computed framework scores for owned assessment", async () => {
+    vi.spyOn(prisma.assessment, "findFirst").mockResolvedValue({
+      id: "asm_1",
+      score: 86,
+    } as never);
+    vi.spyOn(prisma.assessmentItem, "findMany").mockResolvedValue([
       {
-        id: "asm_1",
-        score: 86,
-        numerator: 172,
-        denominator: 200,
+        status: "COMPLIANT",
+        control: {
+          weight: 1,
+          frameworkId: "fw_1",
+          framework: {
+            id: "fw_1",
+            code: "GDPR",
+            name: "GDPR",
+          },
+        },
+      },
+      {
+        status: "PARTIALLY_COMPLIANT",
+        control: {
+          weight: 1,
+          frameworkId: "fw_2",
+          framework: {
+            id: "fw_2",
+            code: "ISO27001",
+            name: "ISO 27001",
+          },
+        },
       },
     ] as never);
 
     const req = new Request("http://localhost/api/assessments/asm_1/score", {
-      method: "POST",
+      method: "GET",
     });
 
-    const res = (await recalculateScorePost(req, { params: { id: "asm_1" } })) as Response;
+    const res = (await scoreGet(req, { params: { id: "asm_1" } })) as Response;
     const json = await res.json();
 
     expect(res.status).toBe(200);
     expect(json.success).toBe(true);
     expect(json.data.assessmentId).toBe("asm_1");
     expect(json.data.score).toBe(86);
-    expect(typeof json.data.calculationDurationMs).toBe("number");
+    expect(json.data.frameworkScores).toEqual([
+      {
+        frameworkId: "fw_1",
+        frameworkCode: "GDPR",
+        frameworkName: "GDPR",
+        score: 100,
+      },
+      {
+        frameworkId: "fw_2",
+        frameworkCode: "ISO27001",
+        frameworkName: "ISO 27001",
+        score: 50,
+      },
+    ]);
   });
 
   it("returns 404 when assessment does not belong to current user", async () => {
     vi.spyOn(prisma.assessment, "findFirst").mockResolvedValue(null as never);
 
     const req = new Request("http://localhost/api/assessments/asm_404/score", {
-      method: "POST",
+      method: "GET",
     });
 
-    const res = (await recalculateScorePost(req, { params: { id: "asm_404" } })) as Response;
+    const res = (await scoreGet(req, { params: { id: "asm_404" } })) as Response;
 
     expect(res.status).toBe(404);
-    expect(prisma.$queryRaw).not.toHaveBeenCalled();
+    expect(prisma.assessmentItem.findMany).not.toHaveBeenCalled();
   });
 
   it("maps auth failures to 401", async () => {
     vi.spyOn(authHelpers, "requireAuth").mockRejectedValue(new Error("401: Unauthorized"));
 
     const req = new Request("http://localhost/api/assessments/asm_1/score", {
-      method: "POST",
+      method: "GET",
     });
 
-    const res = (await recalculateScorePost(req, { params: { id: "asm_1" } })) as Response;
+    const res = (await scoreGet(req, { params: { id: "asm_1" } })) as Response;
 
     expect(res.status).toBe(401);
   });


### PR DESCRIPTION
## Description

Implements Assessment Item Update API and Scoring Engine (Task 4.3).  
Adds item status update with automatic score recalculation, score retrieval endpoint, and checklist API with filtering, sorting, and pagination.


## Type of Change

- [x] feat: New feature
- [ ] fix: Bug fix
- [ ] refactor: Code refactoring
- [ ] docs: Documentation update
- [x] test: Adding or updating tests
- [ ] chore: Build/dependency updates
- [ ] perf: Performance improvement
- [ ] hotfix: Urgent production fix


## Related Issues

Closes Task 4.3 (BE1)


## Changes Made

- Implemented PATCH /api/assessments/:id/items/:itemId for updating item status and comments
- Added automatic score recalculation and persistence on item update
- Implemented GET /api/assessments/:id/score for fetching overall and per-framework scores
- Implemented weighted scoring algorithm as per PRD
- Added GET /api/assessments/:id/items with filtering, search, sorting, and pagination
- Implemented case-insensitive search on control.code, control.title, and comments
- Enforced ownership validation (item → assessment → user)
- Reused existing auth, API helpers, and validation patterns
- Added unit and integration tests for scoring logic and endpoints


## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing performed
- [x] Tested on dev environment


## Screenshots (if applicable)

N/A (backend changes)


## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation (if needed)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] Any dependent changes have been merged


## Additional Notes

- PATCH endpoint recalculates and persists score
- GET /score is read-only and does not trigger recomputation
- Default sorting: severity desc, updatedAt desc
- Severity sorting currently relies on enum order (LOW → CRITICAL)
- Current scoring approach recalculates on each update (acceptable for current scale)