### PR TITLE
Feat/fe1/report integration (#124)

### DIFF
--- a/app/(user)/assessments/[id]/checklist/page.tsx
+++ b/app/(user)/assessments/[id]/checklist/page.tsx
@@ -577,11 +577,11 @@ export default function ChecklistPage() {
             </button>
 
             <button
-              onClick={handleGenerateReport}
+              onClick={() => router.push("/reports")}
               disabled={isHeaderActionPending}
               className="flex items-center gap-2 px-4 py-2 text-sm border border-primary text-primary rounded-lg hover:bg-purple-50 disabled:opacity-60"
             >
-              <FileText className="w-4 h-4" /> Generate Report
+              <FileText className="w-4 h-4" /> View Report
             </button>
             <MoreActionsDropdown
               onExportCsv={exportChecklistCsv}

--- a/app/(user)/assessments/[id]/reports/page.tsx
+++ b/app/(user)/assessments/[id]/reports/page.tsx
@@ -2,35 +2,72 @@
 
 import { useParams } from "next/navigation";
 import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import ExecutiveSummary, { ExecutiveSummarySkeleton } from "@/components/report/ExecutiveSummary";
 
 import Cover from "@/components/report/Cover";
 
 import OrganizationProfile from "@/components/report/OrganizationProfile";
 import RiskAnalysis from "@/components/report/RiskAnalysis";
-
-import { mockReportData } from "@/lib/report-mockData";
 import Roadmap from "@/components/report/Roadmap";
 
-import { generateReport, downloadReport } from "@/lib/report-api";
+import { generateReport, downloadReport, fetchReportView } from "@/lib/report-api";
 import { toast } from "sonner";
+import { ReportViewResponse } from "@/lib/report-types";
 
 export default function ReportPage() {
-  const { id } = useParams();
-  const isLoading = false; // later from useQuery
+  const { id } = useParams<{ id: string }>();
   const [isGenerating, setIsGenerating] = useState(false);
-  const [isDownloading, setIsDownloading] = useState(false);
+  const { data, isLoading: loading } = useQuery({
+    queryKey: ["reportView", id],
+    queryFn: () => fetchReportView(id as string),
+    enabled: !!id,
+  });
+
+  if (loading) {
+    return (
+      <div className="space-y-10">
+        <ExecutiveSummarySkeleton />
+      </div>
+    );
+  }
+
+  if (!data) {
+    return <div className="p-10 text-center text-gray-500">Report not found</div>;
+  }
 
   // 🔹 Handlers
   const handleGenerate = async () => {
     const toastId = toast.loading("Generating report...");
 
     try {
-      await generateReport(id as string);
-      toast.success("Report generated successfully", { id: toastId });
+      // START LOADING
+      setIsGenerating(true);
+
+      // 1. GENERATE REPORT & GET DOWNLOAD URL
+      const { fileUrl: url } = await generateReport(id as string);
+
+      // 3. OPEN PDF
+      const link = document.createElement("a");
+      link.href = url;
+      link.target = "_blank";
+
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+
+      toast.success("Report generated successfully", {
+        id: toastId,
+      });
     } catch (err) {
       console.error(err);
-      toast.error("Failed to generate report", { id: toastId });
+
+      toast.error("Failed to generate report", {
+        id: toastId,
+      });
+    } finally {
+      // STOP LOADING
+      setIsGenerating(false);
     }
   };
 
@@ -47,41 +84,124 @@ export default function ReportPage() {
     }
   };
 
-  const data = mockReportData;
+  const organizationUI: {
+    name: string;
+    systems: string;
+    reportId: string;
+    dataInventory: {
+      category: string;
+      inScope: boolean;
+      examples: string;
+      risk: "LOW" | "MED" | "HIGH";
+    }[];
+    frameworks: {
+      name: string;
+      score: number;
+      controls: number;
+      minorGaps: number;
+      highRisk: number;
+    }[];
+  } = {
+    name: data.organization.productName,
+    systems: data.organization.services,
+    reportId: data.assessment.id,
 
-  // 🔹 MOCK DATA (temporary)
+    dataInventory: data.evidenceRows.map((e) => ({
+      category: e.code,
+      inScope: e.count > 0,
+      examples: e.examples,
+
+      risk: ["CRITICAL", "HIGH"].includes(e.risk.toUpperCase())
+        ? "HIGH"
+        : e.risk.toUpperCase() === "MEDIUM"
+          ? "MED"
+          : e.risk.toUpperCase() === "LOW"
+            ? "LOW"
+            : "HIGH",
+    })),
+
+    frameworks: data.frameworkScores.map((f) => ({
+      name: f.frameworkName,
+
+      score: f.score,
+
+      controls: 0,
+
+      minorGaps: 0,
+
+      highRisk: 0,
+    })),
+  };
+
+  const riskUI = {
+    total: data.riskSummary.totalRiskScore,
+
+    distribution: data.distribution,
+
+    heatmap: data.heatmap,
+
+    remediation: data.controlRows.map((c) => ({
+      id: c.code,
+
+      action: c.title,
+
+      owner: c.owner,
+
+      dueDate: c.targetDate,
+
+      progress: c.progress,
+    })),
+  };
+  const roadmapUI = {
+    summary: {
+      total: data.controlRows.length,
+
+      completed: data.controlRows.filter((c) => c.status === "COMPLIANT").length,
+
+      inProgress: data.controlRows.filter((c) => c.status === "PARTIALLY_COMPLIANT").length,
+
+      overdue: data.controlRows.filter((c) => c.uiStatus === "OVERDUE").length,
+    },
+
+    items: data.controlRows.map((c) => ({
+      id: c.code || "",
+
+      title: c.title || "",
+
+      owner: c.owner || "",
+
+      dueDate: c.targetDate || "",
+
+      status: c.uiStatus || "IN_PROGRESS",
+
+      priority: c.priority || "LOW",
+    })),
+  };
 
   return (
     <div className="space-y-10">
       {/*  Cover Section */}
       <Cover
-        appName={data.appName}
-        frameworks={data.frameworks}
+        appName={data.organization.productName}
+        frameworks={data.frameworkScores.map((f) => f.frameworkCode)}
         generatedAt={data.generatedAt}
-        preparedFor={data.preparedFor}
-        version={data.version}
+        preparedFor={data.organization.productName}
+        version="1.0"
         onGenerate={handleGenerate}
+        isGenerating={isGenerating}
         onDownload={handleDownload}
       />
 
       {/*  Next sections will go here */}
 
-      {isLoading ? (
-        <ExecutiveSummarySkeleton />
-      ) : (
-        <ExecutiveSummary
-          score={data.summary.score}
-          findings={data.summary.findings}
-          alerts={data.summary.alerts}
-        />
-      )}
+      <ExecutiveSummary score={data.overallScore} findings={data.findings} alerts={data.alerts} />
 
       <div className="border-t border-gray-200 my-4" />
-      <OrganizationProfile organization={data.organization} />
+      <OrganizationProfile organization={organizationUI} />
       <div className="border-t border-gray-200 my-4" />
-      <RiskAnalysis data={data.riskAnalysis} />
+      <RiskAnalysis data={riskUI} />
       <div className="border-t border-gray-200 my-4" />
-      <Roadmap roadmap={data.roadmap!} />
+      <Roadmap roadmap={roadmapUI} />
     </div>
   );
 }

--- a/app/(user)/reports/page.tsx
+++ b/app/(user)/reports/page.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useQuery } from "@tanstack/react-query";
+
+import { apiClient } from "@/lib/api-client";
+
+interface AssessmentListItem {
+  id: string;
+  status: "DRAFT" | "IN_PROGRESS" | "COMPLETED";
+  score: number | null;
+  createdAt: string;
+  organizationId: string;
+}
+
+function resolveReportsTarget(assessments: AssessmentListItem[]): string {
+  if (assessments.length > 0) {
+    return `/assessments/${assessments[0].id}/reports`;
+  }
+
+  return "/onboarding";
+}
+
+export default function ReportsIndexPage() {
+  const router = useRouter();
+
+  const assessmentsQuery = useQuery({
+    queryKey: ["reports", "index"],
+    queryFn: () => apiClient.get<AssessmentListItem[]>("/api/assessments"),
+  });
+
+  useEffect(() => {
+    if (!assessmentsQuery.isSuccess) {
+      return;
+    }
+
+    router.replace(resolveReportsTarget(assessmentsQuery.data));
+  }, [assessmentsQuery.data, assessmentsQuery.isSuccess, router]);
+
+  if (assessmentsQuery.isError) {
+    return (
+      <div className="mx-auto max-w-2xl p-6">
+        <div className="rounded-xl border border-red-200 bg-red-50 p-5">
+          <h2 className="text-sm font-semibold text-red-700">Failed to load reports</h2>
+
+          <p className="mt-1 text-sm text-red-600">
+            {assessmentsQuery.error instanceof Error
+              ? assessmentsQuery.error.message
+              : "Please try again."}
+          </p>
+
+          <button
+            onClick={() => void assessmentsQuery.refetch()}
+            className="mt-4 rounded-md bg-red-600 px-3 py-2 text-sm text-white hover:bg-red-700"
+          >
+            Retry
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl p-6">
+      <div className="rounded-xl border border-slate-200 bg-white p-5">
+        <h2 className="text-sm font-semibold text-slate-700">Loading reports...</h2>
+
+        <p className="mt-1 text-sm text-slate-500">Redirecting to your latest report.</p>
+      </div>
+    </div>
+  );
+}

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -13,6 +13,7 @@ import {
   DropdownMenuItem,
 } from "@/components/ui/dropdown-menu";
 import { useAuthStore } from "@/stores/auth-store";
+import { isNavItemActive } from "@/lib/nav-utils";
 
 interface HeaderItem {
   label: string;
@@ -59,7 +60,7 @@ export default function Header({ items = [] }: HeaderProps) {
       {/*  CENTER NAV */}
       <nav className="hidden md:flex items-center gap-8">
         {headerItems.map((item) => {
-          const isActive = pathname.startsWith(item.href);
+          const isActive = isNavItemActive(item, pathname);
 
           return (
             <a

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -4,6 +4,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { ChevronLeft, ChevronRight, LifeBuoy, ShieldCheck } from "lucide-react";
+import { isNavItemActive } from "@/lib/nav-utils";
 
 export default function Sidebar({ items = [], collapsed, setCollapsed, isMobile = false }: any) {
   const pathname = usePathname();
@@ -40,7 +41,7 @@ export default function Sidebar({ items = [], collapsed, setCollapsed, isMobile 
       {/*  NAV */}
       <nav className="flex-1 px-3 py-4 space-y-2 overflow-y-auto">
         {items.map((item: any) => {
-          const isActive = pathname.startsWith(item.href);
+          const isActive = isNavItemActive(item, pathname);
           const Icon = item.icon;
 
           return (

--- a/components/report/Cover.tsx
+++ b/components/report/Cover.tsx
@@ -11,6 +11,7 @@ interface CoverProps {
   version: string;
 
   onGenerate: () => void;
+  isGenerating?: boolean;
   onDownload: () => void;
 }
 
@@ -21,6 +22,7 @@ export default function Cover({
   preparedFor,
   version,
   onGenerate,
+  isGenerating,
   onDownload,
 }: CoverProps) {
   const formattedDate = new Date(generatedAt).toLocaleDateString(undefined, {
@@ -49,11 +51,12 @@ export default function Cover({
           {/*  Export (Generate) */}
           <button
             onClick={onGenerate}
+            disabled={isGenerating}
             className="flex items-center gap-1 px-3 py-1 border rounded 
-            hover:bg-gray-100 hover:shadow-sm transition"
+            hover:bg-gray-100 hover:shadow-sm transition disabled:opacity-50"
           >
+            {isGenerating ? "Generating..." : "Generate Report"}
             <FileDown size={14} />
-            Export
           </button>
 
           {/* ⬇ Download */}

--- a/components/report/OrganizationProfile.tsx
+++ b/components/report/OrganizationProfile.tsx
@@ -25,14 +25,19 @@ export default function OrganizationProfile({ organization }: Props) {
   const dataInventory = organization?.dataInventory ?? [];
   const frameworks = organization?.frameworks ?? [];
 
-  const getRiskColor = (risk: string) => {
+  const getRiskColor = (risk: "LOW" | "MED" | "HIGH" | string) => {
     switch (risk) {
       case "HIGH":
         return "bg-red-100 text-red-600";
+
       case "MED":
         return "bg-yellow-100 text-yellow-600";
+
       case "LOW":
         return "bg-blue-100 text-blue-600";
+
+      default:
+        return "";
     }
   };
 

--- a/components/report/RiskAnalysis.tsx
+++ b/components/report/RiskAnalysis.tsx
@@ -10,8 +10,8 @@ interface Props {
       low: number;
     };
     heatmap: {
-      impact: number;
-      likelihood: number;
+      severity: string;
+      status: string;
       count: number;
     }[];
     remediation: {
@@ -35,11 +35,6 @@ export default function RiskAnalysis({ data }: Props) {
     low: 0,
   };
 
-  const getCellValue = (likelihood: number, impact: number) => {
-    const cell = heatmap.find((h) => h.impact === impact && h.likelihood === likelihood);
-    return cell?.count || 0;
-  };
-
   const total = distribution.critical + distribution.high + distribution.medium + distribution.low;
 
   const safeTotal = total || 1;
@@ -55,6 +50,9 @@ export default function RiskAnalysis({ data }: Props) {
     { value: distribution.medium, color: "#eab308" },
     { value: distribution.low, color: "#22c55e" },
   ];
+  const severities = ["CRITICAL", "HIGH", "MEDIUM", "LOW"];
+
+  const statuses = ["NOT_COMPLIANT", "PARTIALLY_COMPLIANT", "COMPLIANT"];
 
   return (
     <section className="bg-white rounded-xl shadow p-8 space-y-10">
@@ -124,33 +122,58 @@ export default function RiskAnalysis({ data }: Props) {
           <div className="flex items-center justify-center gap-3">
             <p className="text-xs text-gray-500 -rotate-90 whitespace-nowrap">Likelihood</p>
 
-            <div className="grid grid-cols-5 gap-2">
-              {[5, 4, 3, 2, 1].map((likelihood) =>
-                [1, 2, 3, 4, 5].map((impact) => {
-                  const value = getCellValue(likelihood, impact);
+            <div className="grid grid-cols-3 gap-2">
+              {severities.map((severity) =>
+                statuses.map((status) => {
+                  const cell = heatmap.find((h) => h.severity === severity && h.status === status);
+
+                  const value = cell?.count ?? 0;
 
                   let color = "bg-gray-100";
-                  if (value > 10) {
-                    color = "bg-red-500";
-                  } else if (value > 5) {
-                    color = "bg-yellow-400";
-                  } else if (value > 0) {
-                    color = "bg-green-500";
+
+                  if (severity === "CRITICAL") {
+                    color =
+                      status === "NOT_COMPLIANT"
+                        ? "bg-red-500"
+                        : status === "PARTIALLY_COMPLIANT"
+                          ? "bg-red-400"
+                          : "bg-red-300";
+                  } else if (severity === "HIGH") {
+                    color =
+                      status === "NOT_COMPLIANT"
+                        ? "bg-orange-500"
+                        : status === "PARTIALLY_COMPLIANT"
+                          ? "bg-orange-400"
+                          : "bg-orange-300";
+                  } else if (severity === "MEDIUM") {
+                    color =
+                      status === "NOT_COMPLIANT"
+                        ? "bg-yellow-500"
+                        : status === "PARTIALLY_COMPLIANT"
+                          ? "bg-yellow-400"
+                          : "bg-yellow-300";
+                  } else {
+                    color =
+                      status === "NOT_COMPLIANT"
+                        ? "bg-green-500"
+                        : status === "PARTIALLY_COMPLIANT"
+                          ? "bg-green-400"
+                          : "bg-green-300";
                   }
 
                   return (
-                    <div key={`${impact}-${likelihood}`} className="relative group">
+                    <div key={`${severity}-${status}`} className="relative group">
                       <div
-                        className={`h-12 w-12 rounded flex items-center justify-center text-xs font-medium text-white ${color}`}
+                        className={`h-16 w-24 rounded flex flex-col items-center justify-center text-xs font-medium text-white ${color}`}
                       >
-                        {value || ""}
+                        <span>{value}</span>
+
+                        <span className="text-[10px]">{severity}</span>
                       </div>
 
-                      {value > 0 && (
-                        <div className="absolute bottom-full mb-2 hidden group-hover:block bg-black text-white text-[10px] px-2 py-1 rounded whitespace-nowrap z-10">
-                          {value} risks • Impact {impact}, Likelihood {likelihood}
-                        </div>
-                      )}
+                      <div className="absolute bottom-full mb-2 hidden group-hover:block bg-black text-white text-[10px] px-2 py-1 rounded whitespace-nowrap z-10">
+                        {status} • {value} controls
+                      </div>
                     </div>
                   );
                 }),

--- a/components/report/Roadmap.tsx
+++ b/components/report/Roadmap.tsx
@@ -99,7 +99,7 @@ export default function Roadmap({ roadmap }: Props) {
                   <h4 className="text-sm font-semibold text-gray-700">{item.title}</h4>
 
                   <span className={`text-xs px-2 py-1 rounded ${getStatusColor(item.status)}`}>
-                    {item.status.replace("_", " ")}
+                    {item.status?.replaceAll("_", " ") ?? "UNKNOWN"}
                   </span>
                 </div>
 

--- a/lib/nav-utils.ts
+++ b/lib/nav-utils.ts
@@ -1,0 +1,13 @@
+export function isNavItemActive(item: { label: string; href: string }, pathname: string): boolean {
+  const isReportsPage = pathname.includes("/reports");
+  const isAssessmentPage = pathname.includes("/assessments") && !pathname.includes("/reports");
+
+  if (item.label === "Reports") {
+    return isReportsPage;
+  }
+  if (item.label === "Assessments") {
+    return isAssessmentPage;
+  }
+
+  return pathname.startsWith(item.href);
+}

--- a/lib/report-api.ts
+++ b/lib/report-api.ts
@@ -1,12 +1,16 @@
 import { apiClient } from "@/lib/api-client";
-import { ReportData } from "./report-types";
+import { ReportData, ReportViewResponse } from "./report-types";
 
 export const fetchReport = async (assessmentId: string) => {
   return await apiClient.get<ReportData>(`/api/reports/${assessmentId}`);
 };
 
+export const fetchReportView = async (assessmentId: string) => {
+  return await apiClient.get<ReportViewResponse>(`/api/reports/${assessmentId}/view`);
+};
+
 export const generateReport = async (assessmentId: string) => {
-  return await apiClient.post(`/api/reports/${assessmentId}/generate`);
+  return await apiClient.post<{ fileUrl: string }>(`/api/reports/${assessmentId}/generate`);
 };
 
 export const downloadReport = async (assessmentId: string) => {

--- a/lib/report-types.ts
+++ b/lib/report-types.ts
@@ -58,3 +58,150 @@ export interface RoadmapItem {
   status: Status;
   priority: Priority;
 }
+export interface HeatmapItem {
+  severity: string;
+  status: string;
+  count: number;
+}
+export interface ReportViewResponse {
+  reportTitle: string;
+
+  generatedAt: string;
+
+  overallScore: number;
+
+  completionPercent: number;
+
+  readinessBand: string;
+
+  executiveSummary: string;
+
+  findings: {
+    type: "success" | "warning" | "info" | "insight";
+    text: string;
+  }[];
+
+  alerts: {
+    title: string;
+    description: string;
+  }[];
+
+  criticalRisksCount: number;
+
+  criticalRisks: {
+    code: string;
+    title: string;
+    severity: string;
+    status: string;
+  }[];
+
+  topRecommendations: {
+    title: string;
+  }[];
+
+  frameworkScores: {
+    frameworkCode: string;
+    frameworkName: string;
+    score: number;
+  }[];
+
+  riskSummary: {
+    totalRiskScore: number;
+    openHighRisks: number;
+    openMediumRisks: number;
+    openLowRisks: number;
+    riskLevel: string;
+  };
+
+  distribution: {
+    critical: number;
+    high: number;
+    medium: number;
+    low: number;
+  };
+
+  heatmap: HeatmapItem[];
+
+  remediation: {
+    title: string;
+    priority: string;
+    effort: string;
+    rationale: string;
+    score: number;
+  }[];
+
+  controlRows: {
+    code: string;
+
+    title: string;
+
+    frameworkCode: string;
+
+    frameworkName: string;
+
+    severity: "LOW" | "MEDIUM" | "HIGH" | "CRITICAL";
+
+    status:
+      | "NOT_STARTED"
+      | "COMPLIANT"
+      | "PARTIALLY_COMPLIANT"
+      | "NOT_COMPLIANT"
+      | "NOT_APPLICABLE";
+
+    evidenceCount: number;
+
+    riskScore: number;
+
+    owner: string;
+
+    targetDate: string;
+
+    uiStatus: "COMPLETED" | "IN_PROGRESS" | "OVERDUE";
+
+    priority: "HIGH" | "MED" | "LOW";
+
+    progress: number;
+  }[];
+
+  evidenceRows: {
+    code: string;
+
+    title: string;
+
+    count: number;
+
+    examples: string;
+
+    risk: string;
+  }[];
+
+  organization: {
+    id: string;
+
+    productName: string;
+
+    description: string;
+
+    services: string;
+
+    targetCustomers: string;
+
+    problemSolved: string;
+
+    dataHandled: string[];
+
+    regions: string[];
+  };
+
+  assessment: {
+    id: string;
+
+    status: string;
+
+    score: number | null;
+
+    createdAt: string;
+
+    completedAt: string | null;
+  };
+}


### PR DESCRIPTION
* feat/fe1/report-integration

* refactor(report): resolve dashboard architectural and data-integrity audit issues

- Migrate fetchReportView to lib/report-api.ts using apiClient to restore auth tokens and fix routing warnings
- Resolve report generation race condition by extracting the download URL directly from the generation endpoint response
- Map CRITICAL risk levels explicitly to HIGH and apply high-risk defaults for unknown risk metrics
- Exclude NOT_STARTED controls from progress metrics and dynamically calculate overdue control count
- Refactor report page fetching architecture from useState/useEffect hook to TanStack react-query useQuery
- Upgrade risk heatmap to modulate cell color intensity by both severity and compliance status (2D visual mapping)
- Deduplicate active-tab evaluation logic by extracting shared nav matcher to lib/nav-utils.ts
- Prevent undefined classes in risk badges by adding a default fallback branch to getRiskColor

---------