### PR TITLE
fix(be1): wire up hybrid ai remediation drawer

### DIFF
--- a/app/(user)/assessments/[id]/checklist/page.tsx
+++ b/app/(user)/assessments/[id]/checklist/page.tsx
@@ -18,6 +18,7 @@ import { type AssessmentSortField, useAssessmentStore } from "@/stores/assessmen
 import MetricsBar from "@/components/assessment-checklist/MetricsBar";
 import FilterBar from "@/components/assessment-checklist/FilterBar";
 import ChecklistGroup from "@/components/assessment-checklist/ChecklistGroup";
+import RemediationDrawer from "@/components/ai/remediation-drawer";
 import Pagination from "@/components/assessment-checklist/Pagination";
 import Skeleton from "@/components/assessment-checklist/Skeleton";
 import EmptyState from "@/components/assessment-checklist/EmptyState";
@@ -216,6 +217,35 @@ export default function ChecklistPage() {
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(50);
   const [isHeaderActionPending, setIsHeaderActionPending] = useState(false);
+
+  const [remediationOpen, setRemediationOpen] = useState(false);
+  const [remediationContext, setRemediationContext] = useState<{
+    controlId: string;
+    assessmentItemId: string;
+    controlTitle: string;
+    controlDescription: string;
+    framework: string;
+    status: string;
+    severity: string;
+  } | null>(null);
+
+  const openRemediationDrawer = (context: {
+    controlId: string;
+    assessmentItemId: string;
+    controlTitle: string;
+    controlDescription: string;
+    framework: string;
+    status: string;
+    severity: string;
+  }) => {
+    setRemediationContext(context);
+    setRemediationOpen(true);
+  };
+
+  const closeRemediationDrawer = () => {
+    setRemediationOpen(false);
+    setRemediationContext(null);
+  };
 
   useEffect(() => {
     return () => {
@@ -624,6 +654,7 @@ export default function ChecklistPage() {
           controls={group.controls}
           assessmentId={assessmentId}
           updatingItemId={updatingItemId}
+          onOpenRemediation={openRemediationDrawer}
           onStatusChange={(itemId, nextStatus) => {
             updateStatusMutation.mutate(
               {
@@ -652,6 +683,20 @@ export default function ChecklistPage() {
         perPage={perPage}
         setPerPage={setPerPage}
       />
+
+      {remediationContext && (
+        <RemediationDrawer
+          open={remediationOpen}
+          onClose={closeRemediationDrawer}
+          controlId={remediationContext.controlId}
+          assessmentItemId={remediationContext.assessmentItemId}
+          controlTitle={remediationContext.controlTitle}
+          controlDescription={remediationContext.controlDescription}
+          framework={remediationContext.framework}
+          status={remediationContext.status}
+          severity={remediationContext.severity}
+        />
+      )}
     </div>
   );
 }

--- a/components/assessment-checklist/ChecklistGroup.tsx
+++ b/components/assessment-checklist/ChecklistGroup.tsx
@@ -9,6 +9,15 @@ interface Props {
   assessmentId?: string;
   onStatusChange?: (itemId: string, status: Status) => void;
   updatingItemId?: string | null;
+  onOpenRemediation?: (context: {
+    controlId: string;
+    assessmentItemId: string;
+    controlTitle: string;
+    controlDescription: string;
+    framework: string;
+    status: string;
+    severity: string;
+  }) => void;
 }
 
 export default function ChecklistGroup({
@@ -18,6 +27,7 @@ export default function ChecklistGroup({
   assessmentId,
   onStatusChange,
   updatingItemId,
+  onOpenRemediation,
 }: Props) {
   const [open, setOpen] = useState(false);
   const completed = controls.filter((c) => c.status === "COMPLIANT").length;
@@ -77,6 +87,7 @@ export default function ChecklistGroup({
               assessmentId={assessmentId}
               onStatusChange={onStatusChange}
               isStatusUpdating={updatingItemId === c.itemId}
+              onOpenRemediation={onOpenRemediation}
             />
           ))}
         </div>

--- a/components/assessment-checklist/ControlCard.tsx
+++ b/components/assessment-checklist/ControlCard.tsx
@@ -22,6 +22,15 @@ interface Props {
   assessmentId?: string;
   onStatusChange?: (itemId: string, status: Status) => void;
   isStatusUpdating?: boolean;
+  onOpenRemediation?: (context: {
+    controlId: string;
+    assessmentItemId: string;
+    controlTitle: string;
+    controlDescription: string;
+    framework: string;
+    status: string;
+    severity: string;
+  }) => void;
 }
 
 export default function ControlCard({
@@ -29,6 +38,7 @@ export default function ControlCard({
   assessmentId,
   onStatusChange,
   isStatusUpdating = false,
+  onOpenRemediation,
 }: Props) {
   const [open, setOpen] = useState(false);
   const [commentsOpen, setCommentsOpen] = useState(true);
@@ -130,7 +140,7 @@ export default function ControlCard({
                 {statusConfig[control.status]?.icon}
                 Status: {control.status}
               </p>
-              <p>Updated: {control.updatedAt} by Sarah Chen</p>
+              <p>Updated: {control.updatedAt}</p>
               <button className="text-purple-600 text-xs hover:underline">View history →</button>
             </div>
 
@@ -144,13 +154,41 @@ export default function ControlCard({
                 </p>
 
                 <p className="text-sm mt-2 opacity-90">
-                  We’ve identified that you are missing a formal Risk Register. AI can generate a
-                  compliant template for you.
+                  {control.description.length > 240
+                    ? `${control.description.slice(0, 237).trim()}...`
+                    : control.description}
                 </p>
 
-                <button className="mt-4 bg-white text-purple-700 px-4 py-2 rounded-md text-sm font-medium">
-                  Get AI Remediation Plan →
-                </button>
+                {assessmentId && onOpenRemediation ? (
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onOpenRemediation({
+                        controlId: control.id,
+                        assessmentItemId: control.itemId,
+                        controlTitle: control.title,
+                        controlDescription: control.description,
+                        framework: control.framework,
+                        status: control.status,
+                        severity: control.severity,
+                      });
+                    }}
+                    className="mt-4 inline-block bg-white text-purple-700 px-4 py-2 rounded-md text-sm font-medium"
+                  >
+                    Get AI Remediation Plan →
+                  </button>
+                ) : assessmentId ? (
+                  <Link
+                    href={`/assessments/${assessmentId}/control-workspace/${control.id}`}
+                    className="mt-4 inline-block bg-white text-purple-700 px-4 py-2 rounded-md text-sm font-medium"
+                  >
+                    Get AI Remediation Plan →
+                  </Link>
+                ) : (
+                  <button className="mt-4 bg-white text-purple-700 px-4 py-2 rounded-md text-sm font-medium">
+                    Get AI Remediation Plan →
+                  </button>
+                )}
               </div>
             )}
 
@@ -173,14 +211,17 @@ export default function ControlCard({
               </div>
 
               <div className="flex gap-3">
-                <div className="flex items-center gap-2 border border-slate-300 rounded-lg px-3 py-2 text-sm">
-                  <FileText className="text-red-500" size={16} />
-                  Risk_Assessment.pdf
-                </div>
-
-                <div className="border-dashed border border-slate-300 rounded-lg px-4 py-2 text-sm text-gray-500 flex items-center gap-2">
-                  <Plus size={14} /> Attach file
-                </div>
+                {assessmentId ? (
+                  <Link
+                    href={`/assessments/${assessmentId}/control-workspace/${control.id}`}
+                    className="inline-flex items-center gap-2 border border-slate-300 rounded-lg px-3 py-2 text-sm text-purple-600"
+                  >
+                    <FileText size={16} />
+                    View workspace
+                  </Link>
+                ) : (
+                  <div className="text-sm text-gray-500">No evidence available</div>
+                )}
               </div>
             </div>
 


### PR DESCRIPTION
## Description

Wire the assessment checklist CTA to the inline hybrid AI remediation drawer. This enables users to generate and manage AI remediation plans directly from checklist controls while preserving the existing full remediation workspace as a fallback.

## Type of Change

* [x] feat: New feature
* [x] fix: Bug fix
* [ ] refactor: Code refactoring
* [ ] docs: Documentation update
* [ ] test: Adding or updating tests
* [ ] chore: Build/dependency updates
* [ ] perf: Performance improvement
* [ ] hotfix: Urgent production fix

## Changes Made

* Wired the "Get AI Remediation Plan" CTA in checklist controls to open the inline hybrid AI remediation drawer.
* Added support for launching remediation workflows directly from NOT_COMPLIANT controls.
* Preserved the existing full remediation workspace flow as a fallback via the "Open full workspace" action.
* Updated component integration across `ControlCard.tsx`, `ChecklistGroup.tsx`, and the assessment checklist page.

## Testing

* [ ] Unit tests added/updated
* [ ] Integration tests added/updated
* [ ] E2E tests added/updated
* [x] Manual testing performed
* [x] Tested on dev environment

## Checklist

* [x] My code follows the project's coding standards
* [x] I have performed a self-review of my code
* [ ] I have commented my code where necessary
* [ ] I have updated the documentation (if needed)
* [x] My changes generate no new warnings
* [ ] I have added tests that prove my fix/feature works
* [ ] New and existing tests pass locally
* [ ] Any dependent changes have been merged

